### PR TITLE
修复部分线程创建无法插桩的问题

### DIFF
--- a/booster-transform-thread/src/main/kotlin/com/didiglobal/booster/transform/thread/ThreadTransformer.kt
+++ b/booster-transform-thread/src/main/kotlin/com/didiglobal/booster/transform/thread/ThreadTransformer.kt
@@ -169,30 +169,33 @@ class ThreadTransformer : ClassTransformer {
 
     private fun TypeInsnNode.transformWithName(context: TransformContext, klass: ClassNode, method: MethodNode, type: String, prefix: String = "") {
         this.find {
-            it.opcode == Opcodes.INVOKESPECIAL
-        }?.isInstanceOf { init: MethodInsnNode ->
-            if (this.desc == init.owner && "<init>" == init.name) {
-                val name = "new${prefix.capitalize()}${this.desc.substringAfterLast('/')}"
-                val desc = "${init.desc.substringBeforeLast(')')}Ljava/lang/String;)L${this.desc};"
-                logger.println(" * ${init.owner}.${init.name}${init.desc} => $type.$name$desc: ${klass.name}.${method.name}${method.desc}")
-                // replace NEW with INVOKESTATIC
-                init.owner = type
-                init.name = name
-                init.desc = desc
-                init.opcode = Opcodes.INVOKESTATIC
-                init.itf = false
-                // add name as last parameter
-                method.instructions.insertBefore(init, LdcInsnNode(makeThreadName(klass.className)))
+            (it.opcode == Opcodes.INVOKESPECIAL) &&
+                    (it is MethodInsnNode) &&
+                    (this.desc == it.owner && "<init>" == it.name)
+        }?.let { init: AbstractInsnNode ->
+            if (init !is MethodInsnNode) return
+            val name = "new${prefix.capitalize()}${this.desc.substringAfterLast('/')}"
+            val desc = "${init.desc.substringBeforeLast(')')}Ljava/lang/String;)L${this.desc};"
+            logger.println(" * ${init.owner}.${init.name}${init.desc} => $type.$name$desc: ${klass.name}.${method.name}${method.desc}")
+            // replace NEW with INVOKESTATIC
+            init.owner = type
+            init.name = name
+            init.desc = desc
+            init.opcode = Opcodes.INVOKESTATIC
+            init.itf = false
+            // add name as last parameter
+            method.instructions.insertBefore(init, LdcInsnNode(makeThreadName(klass.className)))
 
-                // remove the next DUP of NEW
-                val dup = this.next
-                if (Opcodes.DUP == dup.opcode) {
-                    method.instructions.remove(dup)
-                } else {
-                    TODO("Unexpected instruction 0x${dup.opcode.toString(16)}: ${klass.name}.${method.name}${method.desc}")
-                }
-                method.instructions.remove(this)
+            // remove the next DUP of NEW
+            val dup = this.next
+            if (Opcodes.DUP == dup.opcode) {
+                method.instructions.remove(dup)
+            } else {
+                TODO("Unexpected instruction 0x${dup.opcode.toString(16)}: ${klass.name}.${method.name}${method.desc}")
             }
+            method.instructions.remove(this)
+        }?: run {
+            logger.println(" ! failed to match $desc: ${klass.name}.${method.name}${method.desc}")
         }
     }
 

--- a/booster-transform-thread/src/main/kotlin/com/didiglobal/booster/transform/thread/ThreadTransformer.kt
+++ b/booster-transform-thread/src/main/kotlin/com/didiglobal/booster/transform/thread/ThreadTransformer.kt
@@ -172,8 +172,7 @@ class ThreadTransformer : ClassTransformer {
             (it.opcode == Opcodes.INVOKESPECIAL) &&
                     (it is MethodInsnNode) &&
                     (this.desc == it.owner && "<init>" == it.name)
-        }?.let { init ->
-            if (init !is MethodInsnNode) return
+        }?.isInstanceOf { init: MethodInsnNode ->
             val name = "new${prefix.capitalize()}${this.desc.substringAfterLast('/')}"
             val desc = "${init.desc.substringBeforeLast(')')}Ljava/lang/String;)L${this.desc};"
             logger.println(" * ${init.owner}.${init.name}${init.desc} => $type.$name$desc: ${klass.name}.${method.name}${method.desc}")

--- a/booster-transform-thread/src/main/kotlin/com/didiglobal/booster/transform/thread/ThreadTransformer.kt
+++ b/booster-transform-thread/src/main/kotlin/com/didiglobal/booster/transform/thread/ThreadTransformer.kt
@@ -172,7 +172,7 @@ class ThreadTransformer : ClassTransformer {
             (it.opcode == Opcodes.INVOKESPECIAL) &&
                     (it is MethodInsnNode) &&
                     (this.desc == it.owner && "<init>" == it.name)
-        }?.let { init: AbstractInsnNode ->
+        }?.let { init ->
             if (init !is MethodInsnNode) return
             val name = "new${prefix.capitalize()}${this.desc.substringAfterLast('/')}"
             val desc = "${init.desc.substringBeforeLast(')')}Ljava/lang/String;)L${this.desc};"


### PR DESCRIPTION
我在集成 booster-transform-thread 中发现我们工程里的某些 ```new ThreadPoolExecutor```的调用没有成功插桩。研究源码后，发现是寻找```INVOKESPECIAL```指令的过程逻辑有误导致。bad case 如下：

```
// case 1 无法插桩
ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(2, 2, KEEP_ALIVE_TIME, TimeUnit.SECONDS, new PriorityBlockingQueue<Runnable>(),
                    new PriorityThreadFactory("thread_pool", android.os.Process.THREAD_PRIORITY_BACKGROUND));

// case 2 这个无法插桩
new Thread(r, "AsyncTask ##" + mCount.getAndIncrement());
```

它们的共同点是：构造器的传参也是直接 new 出来的。

而插桩失败原因是，```Opcodes.NEW```分支中的```transformWithName```中的```find```逻辑，会返回第一个匹配```it.opcode == Opcodes.INVOKESPECIAL```的指令。

```
this.find {
    it.opcode == Opcodes.INVOKESPECIAL
}?.isInstanceOf { init: MethodInsnNode ->
    if (this.desc == init.owner && "<init>" == init.name) {
        // do something
    }
}
```

此时会检查匹配到的指令是否符合进一步的条件（在 case 1 中就是，是不是真的是 new ThreadPoolExecutor)，如果不是就直接退出了。

在 case 1 中，第一个匹配到的是  ```new PriorityBlockingQueue```，第二个是 ```new PriorityThreadFactory```，第三个才是 ```new ThreadPoolExecutor``` 。

修复方法是：把所有判断逻辑都放在 ```find``` 中。

```
this.find {
        (it.opcode == Opcodes.INVOKESPECIAL) &&
            (it is MethodInsnNode) &&
            (this.desc == it.owner && "<init>" == it.name)
}?.let { init: AbstractInsnNode ->
    if (init !is MethodInsnNode) return
    // do something
}
```



