### PR TITLE
v3.1.0

### DIFF
--- a/booster-aapt2/src/main/kotlin/com/didiglobal/booster/aapt2/Aapt2Container.kt
+++ b/booster-aapt2/src/main/kotlin/com/didiglobal/booster/aapt2/Aapt2Container.kt
@@ -13,9 +13,13 @@ class Aapt2Container(val header: Header, private vararg val _entries: Entry<*>) 
 
     data class Metadata(val resourceName: String, val sourcePath: String, val configuration: Configuration) {
 
-        val sourceFile = File(sourcePath)
+        val sourceFile: File by lazy {
+            File(sourcePath)
+        }
 
-        val resourcePath = "${sourceFile.parentFile.name}${File.separatorChar}${sourceFile.name}"
+        val resourcePath: String by lazy {
+            sourceFile.resourcePath
+        }
 
     }
 
@@ -27,7 +31,7 @@ class Aapt2Container(val header: Header, private vararg val _entries: Entry<*>) 
 
     open class Png(header: ResourcesInternal.CompiledFile, val image: ByteBuffer) : ResFile(header)
 
-    open class Xml(file: ResourcesInternal.CompiledFile, val root: Resources.XmlNode): ResFile(file)
+    open class Xml(file: ResourcesInternal.CompiledFile, val root: Resources.XmlNode) : ResFile(file)
 
     val entries: List<Entry<*>>
         get() = listOf(*_entries)

--- a/booster-aapt2/src/main/kotlin/com/didiglobal/booster/aapt2/Aapt2Parser.kt
+++ b/booster-aapt2/src/main/kotlin/com/didiglobal/booster/aapt2/Aapt2Parser.kt
@@ -261,8 +261,11 @@ private fun BinaryParser.parsePng(header: ResourcesInternal.CompiledFile): Png {
 }
 
 val ResourcesInternal.CompiledFile.resourcePath: String
-    get() {
-        val src = File(this.sourcePath)
-        return "${src.parentFile.name}${File.separatorChar}${src.name}"
-    }
+    get() = File(this.sourcePath).resourcePath
+
+val File.resourcePath: String
+    get() = "${parentFile.name}${File.separatorChar}${name}"
+
+val File.resourceName: String
+    get() = "${parentFile.name}${File.separatorChar}${nameWithoutExtension}"
 

--- a/booster-aapt2/src/main/kotlin/com/didiglobal/booster/aapt2/Aapt2Parser.kt
+++ b/booster-aapt2/src/main/kotlin/com/didiglobal/booster/aapt2/Aapt2Parser.kt
@@ -267,5 +267,5 @@ val File.resourcePath: String
     get() = "${parentFile.name}${File.separatorChar}${name}"
 
 val File.resourceName: String
-    get() = "${parentFile.name}${File.separatorChar}${nameWithoutExtension}"
+    get() = "${parentFile.name.substringBefore('-')}${File.separatorChar}${nameWithoutExtension}"
 

--- a/booster-android-instrument-activity-thread/src/main/java/com/didiglobal/booster/instrument/ActivityThreadCallback.java
+++ b/booster-android-instrument-activity-thread/src/main/java/com/didiglobal/booster/instrument/ActivityThreadCallback.java
@@ -104,13 +104,19 @@ class ActivityThreadCallback implements Handler.Callback {
 
     private void rethrowIfCausedByUser(final RuntimeException e) {
         if (isCausedByUser(e)) {
-            throw sanitizeStackTrace(e, getClass());
+            for (Throwable cause = e; null != cause; cause = cause.getCause()) {
+                sanitizeStackTrace(cause, getClass());
+            }
+            throw e;
         }
     }
 
     private void rethrowIfCausedByUser(final Error e) {
         if (isCausedByUser(e)) {
-            throw sanitizeStackTrace(e, getClass());
+            for (Throwable cause = e; null != cause; cause = cause.getCause()) {
+                sanitizeStackTrace(cause, getClass());
+            }
+            throw e;
         }
     }
 

--- a/booster-android-instrument/src/main/java/com/didiglobal/booster/instrument/Intrinsics.java
+++ b/booster-android-instrument/src/main/java/com/didiglobal/booster/instrument/Intrinsics.java
@@ -1,6 +1,8 @@
 package com.didiglobal.booster.instrument;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
 
 public abstract class Intrinsics {
 
@@ -8,17 +10,22 @@ public abstract class Intrinsics {
         return sanitizeStackTrace(throwable, clazz.getName());
     }
 
+    @SuppressWarnings("Java8CollectionRemoveIf")
     public static <T extends Throwable> T sanitizeStackTrace(T throwable, String classNameToDrop) {
         final StackTraceElement[] stackTrace = throwable.getStackTrace();
-        final ArrayList<StackTraceElement> newStackTrace = new ArrayList<>(stackTrace.length);
+        final ArrayList<StackTraceElement> newStackTrace = new ArrayList<>(Arrays.asList(stackTrace));
 
-        for (StackTraceElement ste : stackTrace) {
-            if (!classNameToDrop.equals(ste.getClassName())) {
-                newStackTrace.add(ste);
+        for (final Iterator<StackTraceElement> i = newStackTrace.iterator(); i.hasNext();) {
+            final StackTraceElement ste = i.next();
+            if (classNameToDrop.equals(ste.getClassName())) {
+                i.remove();
             }
         }
 
-        throwable.setStackTrace(newStackTrace.toArray(new StackTraceElement[0]));
+        if (stackTrace.length != newStackTrace.size()) {
+            throwable.setStackTrace(newStackTrace.toArray(new StackTraceElement[0]));
+        }
+
         return throwable;
     }
 

--- a/booster-task-compression-cwebp/README.md
+++ b/booster-task-compression-cwebp/README.md
@@ -6,9 +6,10 @@ This module is used for assets and resource compression using `cwebp`
 
 The following table shows the properties that transformer supports:
 
-| Property                                 | Description                              |
-| ---------------------------------------- | ---------------------------------------- |
-| `booster.task.compression.cwebp.quality` | compression quality (the default is 80)  |
+| Property                                 | Description                              | Example                            |
+| ---------------------------------------- | ---------------------------------------- | ---------------------------------- |
+| `booster.task.compression.cwebp.quality` | compression quality (the default is 80)  |                                    |
+| `booster.task.compression.cwebp.ignores` | ignore wildcards (separated by comma)    | `mipmap/*,drawable/abc_*`          | 
 
 ## Using `cwebp`
 

--- a/booster-task-compression-cwebp/README.md
+++ b/booster-task-compression-cwebp/README.md
@@ -6,10 +6,10 @@ This module is used for assets and resource compression using `cwebp`
 
 The following table shows the properties that transformer supports:
 
-| Property                                 | Description                              | Example                            |
-| ---------------------------------------- | ---------------------------------------- | ---------------------------------- |
-| `booster.task.compression.cwebp.quality` | compression quality (the default is 80)  |                                    |
-| `booster.task.compression.cwebp.ignores` | ignore wildcards (separated by comma)    | `mipmap/*,drawable/abc_*`          | 
+| Property                                 | Description                              | Example                                     |
+| ---------------------------------------- | ---------------------------------------- | ------------------------------------------- |
+| `booster.task.compression.cwebp.quality` | compression quality (the default is 80)  |                                             |
+| `booster.task.compression.cwebp.ignores` | ignore wildcards (separated by comma)    | `mipmap/ic_launcher*,drawable/ic_launcher*` |
 
 ## Using `cwebp`
 

--- a/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressFlatImages.kt
+++ b/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressFlatImages.kt
@@ -60,6 +60,8 @@ internal open class CwebpCompressFlatImages : AbstractCwebpCompressImages() {
         images.parallelStream().map {
             it to it.metadata
         }.filter {
+            this.filter(it.second.resourceName)
+        }.filter {
             isNotLauncherIcon(it.first, it.second)
         }.filter {
             filter(File(it.second.sourcePath))

--- a/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressFlatImages.kt
+++ b/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressFlatImages.kt
@@ -50,7 +50,7 @@ internal open class CwebpCompressFlatImages : AbstractCwebpCompressImages() {
 
         // Google Play only accept APK with PNG format launcher icon
         // https://developer.android.com/topic/performance/reduce-apk-size#use-webp
-        val isNotLauncherIcon: (File, Aapt2Container.Metadata) -> Boolean = { input, metadata ->
+        val isNotLauncherIcon: (Pair<File, Aapt2Container.Metadata>) -> Boolean = { (input, metadata) ->
             if (!icons.contains(metadata.resourceName)) true else false.also {
                 val s0 = input.length()
                 results.add(CompressionResult(input, s0, s0, File(metadata.sourcePath)))
@@ -59,11 +59,7 @@ internal open class CwebpCompressFlatImages : AbstractCwebpCompressImages() {
 
         images.parallelStream().map {
             it to it.metadata
-        }.filter {
-            this.filter(it.second.resourceName)
-        }.filter {
-            isNotLauncherIcon(it.first, it.second)
-        }.filter {
+        }.filter(this::shouldIgnore).filter(isNotLauncherIcon).filter {
             filter(File(it.second.sourcePath))
         }.map {
             val output = compressedRes.file("${it.second.resourcePath.substringBeforeLast('.')}.webp")

--- a/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressFlatImages.kt
+++ b/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressFlatImages.kt
@@ -52,14 +52,13 @@ internal open class CwebpCompressFlatImages : AbstractCwebpCompressImages() {
         // https://developer.android.com/topic/performance/reduce-apk-size#use-webp
         val isNotLauncherIcon: (Pair<File, Aapt2Container.Metadata>) -> Boolean = { (input, metadata) ->
             if (!icons.contains(metadata.resourceName)) true else false.also {
-                val s0 = input.length()
-                results.add(CompressionResult(input, s0, s0, File(metadata.sourcePath)))
+                ignore(metadata.resourceName, input, File(metadata.sourcePath))
             }
         }
 
         images.parallelStream().map {
             it to it.metadata
-        }.filter(this::shouldIgnore).filter(isNotLauncherIcon).filter {
+        }.filter(this::includes).filter(isNotLauncherIcon).filter {
             filter(File(it.second.sourcePath))
         }.map {
             val output = compressedRes.file("${it.second.resourcePath.substringBeforeLast('.')}.webp")

--- a/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressImages.kt
+++ b/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressImages.kt
@@ -22,7 +22,7 @@ internal open class CwebpCompressImages : AbstractCwebpCompressImages() {
 
     override fun compress(filter: (File) -> Boolean) {
         val cwebp = compressor.canonicalPath
-        images.parallelStream().filter(this::shouldIgnore).filter(filter).map { input ->
+        images.parallelStream().filter(this::includes).filter(filter).map { input ->
             val output = File(input.absolutePath.substringBeforeLast('.') + ".webp")
             ActionData(input, output, listOf(cwebp, "-mt", "-quiet", "-q", options.quality.toString(), "-o", output.absolutePath, input.absolutePath))
         }.forEach {

--- a/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressImages.kt
+++ b/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressImages.kt
@@ -1,5 +1,6 @@
 package com.didiglobal.booster.task.compression.cwebp
 
+import com.android.SdkConstants
 import com.didiglobal.booster.compression.CompressionResult
 import com.didiglobal.booster.compression.task.ActionData
 import com.didiglobal.booster.kotlinx.CSI_RED
@@ -22,7 +23,9 @@ internal open class CwebpCompressImages : AbstractCwebpCompressImages() {
 
     override fun compress(filter: (File) -> Boolean) {
         val cwebp = compressor.canonicalPath
-        images.parallelStream().filter(filter).map { input ->
+        images.parallelStream().filter {
+            this.filter("${it.parent.substringBefore(SdkConstants.RES_QUALIFIER_SEP)}/${it.nameWithoutExtension}")
+        }.filter(filter).map { input ->
             val output = File(input.absolutePath.substringBeforeLast('.') + ".webp")
             ActionData(input, output, listOf(cwebp, "-mt", "-quiet", "-q", options.quality.toString(), "-o", output.absolutePath, input.absolutePath))
         }.forEach {

--- a/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressImages.kt
+++ b/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressImages.kt
@@ -1,6 +1,5 @@
 package com.didiglobal.booster.task.compression.cwebp
 
-import com.android.SdkConstants
 import com.didiglobal.booster.compression.CompressionResult
 import com.didiglobal.booster.compression.task.ActionData
 import com.didiglobal.booster.kotlinx.CSI_RED
@@ -23,9 +22,7 @@ internal open class CwebpCompressImages : AbstractCwebpCompressImages() {
 
     override fun compress(filter: (File) -> Boolean) {
         val cwebp = compressor.canonicalPath
-        images.parallelStream().filter {
-            this.filter("${it.parent.substringBefore(SdkConstants.RES_QUALIFIER_SEP)}/${it.nameWithoutExtension}")
-        }.filter(filter).map { input ->
+        images.parallelStream().filter(this::shouldIgnore).filter(filter).map { input ->
             val output = File(input.absolutePath.substringBeforeLast('.') + ".webp")
             ActionData(input, output, listOf(cwebp, "-mt", "-quiet", "-q", options.quality.toString(), "-o", output.absolutePath, input.absolutePath))
         }.forEach {

--- a/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressionVariantProcessor.kt
+++ b/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressionVariantProcessor.kt
@@ -2,6 +2,7 @@ package com.didiglobal.booster.task.compression.cwebp
 
 import com.android.build.gradle.api.BaseVariant
 import com.didiglobal.booster.compression.CompressionResults
+import com.didiglobal.booster.compression.ResourceNameFilter
 import com.didiglobal.booster.compression.generateReport
 import com.didiglobal.booster.compression.isFlatPngExceptRaw
 import com.didiglobal.booster.compression.isPngExceptRaw
@@ -9,6 +10,7 @@ import com.didiglobal.booster.gradle.aapt2Enabled
 import com.didiglobal.booster.gradle.mergeResourcesTask
 import com.didiglobal.booster.gradle.mergedRes
 import com.didiglobal.booster.gradle.project
+import com.didiglobal.booster.kotlinx.Wildcard
 import com.didiglobal.booster.kotlinx.search
 import com.didiglobal.booster.task.spi.VariantProcessor
 import com.google.auto.service.AutoService
@@ -21,12 +23,21 @@ class CwebpCompressionVariantProcessor : VariantProcessor {
 
     override fun process(variant: BaseVariant) {
         val results = CompressionResults()
-        val filter = if (variant.project.aapt2Enabled) ::isFlatPngExceptRaw else ::isPngExceptRaw
+        val filter: ResourceNameFilter = if (variant.project.hasProperty(PROPERTY_IGNORES)) {
+            val ignores = "${variant.project.property(PROPERTY_IGNORES)}".trim().split(',').map(Wildcard.Companion::valueOf).toSet();
+            { res -> ignores.none { it.matches(res) } }
+        } else {
+            { true }
+        }
         Cwebp.get(variant)?.newCompressionTaskCreator()?.createCompressionTask(variant, results, "resources", {
-            variant.mergedRes.search(filter)
-        }, variant.mergeResourcesTask)?.doLast {
+            variant.mergedRes.search(if (variant.project.aapt2Enabled) ::isFlatPngExceptRaw else ::isPngExceptRaw)
+        }, filter, variant.mergeResourcesTask)?.doLast {
             results.generateReport(variant, Build.ARTIFACT)
         }
     }
 
 }
+
+private val PROPERTY_PREFIX = Build.ARTIFACT.replace('-', '.')
+
+private val PROPERTY_IGNORES = "$PROPERTY_PREFIX.ignores"

--- a/booster-task-compression-pngquant/README.md
+++ b/booster-task-compression-pngquant/README.md
@@ -13,6 +13,7 @@ The following table shows the properties that transformer supports:
 | -------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------- |
 | `booster.task.compression.pngquant.option.quality` | compression quality (this default is 80)                     |                                    | 
 | `booster.task.compression.pngquant.option.speed`   | compression speed (the default is 3)                         |                                    | 
+| `booster.task.compression.pngquant.ignores`        | ignore wildcards (separated by comma)                        | `mipmap/*,drawable/abc_*`          | 
 
 ## Using `pngquant`
 

--- a/booster-task-compression-pngquant/README.md
+++ b/booster-task-compression-pngquant/README.md
@@ -9,11 +9,11 @@ This module is used for assets and resource compression using `pngquant`
 
 The following table shows the properties that transformer supports:
 
-| Property                                           | Description                                                  | Example                            |
-| -------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------- |
-| `booster.task.compression.pngquant.option.quality` | compression quality (this default is 80)                     |                                    | 
-| `booster.task.compression.pngquant.option.speed`   | compression speed (the default is 3)                         |                                    | 
-| `booster.task.compression.pngquant.ignores`        | ignore wildcards (separated by comma)                        | `mipmap/*,drawable/abc_*`          | 
+| Property                                           | Description                               | Example                                     |
+| -------------------------------------------------- | ----------------------------------------- | ------------------------------------------- |
+| `booster.task.compression.pngquant.option.quality` | compression quality (this default is 80)  |                                             | 
+| `booster.task.compression.pngquant.option.speed`   | compression speed (the default is 3)      |                                             | 
+| `booster.task.compression.pngquant.ignores`        | ignore wildcards (separated by comma)     | `mipmap/ic_launcher*,drawable/ic_launcher*` | 
 
 ## Using `pngquant`
 

--- a/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressFlatImages.kt
+++ b/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressFlatImages.kt
@@ -47,7 +47,7 @@ internal open class PngquantCompressFlatImages : AbstractPngquantCompressImages(
 
         images.parallelStream().map {
             it to it.metadata
-        }.filter(this::shouldIgnore).map {
+        }.filter(this::includes).map {
             val output = compressedRes.file("${it.second.resourcePath.substringBeforeLast('.')}$DOT_PNG")
             Aapt2ActionData(it.first, it.second, output,
                     listOf(pngquant, "--strip", "--skip-if-larger", "-f", "-o", output.absolutePath, "-s", "${options.speed}", "-Q", "${options.quality}-100", it.second.sourcePath),

--- a/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressFlatImages.kt
+++ b/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressFlatImages.kt
@@ -47,9 +47,7 @@ internal open class PngquantCompressFlatImages : AbstractPngquantCompressImages(
 
         images.parallelStream().map {
             it to it.metadata
-        }.filter {
-            this.filter(it.second.resourceName)
-        }.map {
+        }.filter(this::shouldIgnore).map {
             val output = compressedRes.file("${it.second.resourcePath.substringBeforeLast('.')}$DOT_PNG")
             Aapt2ActionData(it.first, it.second, output,
                     listOf(pngquant, "--strip", "--skip-if-larger", "-f", "-o", output.absolutePath, "-s", "${options.speed}", "-Q", "${options.quality}-100", it.second.sourcePath),

--- a/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressFlatImages.kt
+++ b/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressFlatImages.kt
@@ -47,6 +47,8 @@ internal open class PngquantCompressFlatImages : AbstractPngquantCompressImages(
 
         images.parallelStream().map {
             it to it.metadata
+        }.filter {
+            this.filter(it.second.resourceName)
         }.map {
             val output = compressedRes.file("${it.second.resourcePath.substringBeforeLast('.')}$DOT_PNG")
             Aapt2ActionData(it.first, it.second, output,

--- a/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressImages.kt
+++ b/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressImages.kt
@@ -24,7 +24,7 @@ internal open class PngquantCompressImages : AbstractPngquantCompressImages() {
     override fun compress() {
         val pngquant = this.compressor.canonicalPath
 
-        images.parallelStream().filter(this::shouldIgnore).map {
+        images.parallelStream().filter(this::includes).map {
             ActionData(it, it, listOf(pngquant, "--strip", "--skip-if-larger", "-f", "--ext", DOT_PNG, "-s", "${options.speed}", "-Q", "${options.quality}-100", it.absolutePath))
         }.forEach {
             val s0 = it.input.length()

--- a/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressImages.kt
+++ b/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressImages.kt
@@ -1,5 +1,6 @@
 package com.didiglobal.booster.task.compression.pngquant
 
+import com.android.SdkConstants
 import com.android.SdkConstants.DOT_PNG
 import com.didiglobal.booster.compression.CompressionResult
 import com.didiglobal.booster.compression.task.ActionData
@@ -24,7 +25,9 @@ internal open class PngquantCompressImages : AbstractPngquantCompressImages() {
     override fun compress() {
         val pngquant = this.compressor.canonicalPath
 
-        images.parallelStream().map {
+        images.parallelStream().filter {
+            this.filter("${it.parent.substringBefore(SdkConstants.RES_QUALIFIER_SEP)}/${it.nameWithoutExtension}")
+        }.map {
             ActionData(it, it, listOf(pngquant, "--strip", "--skip-if-larger", "-f", "--ext", DOT_PNG, "-s", "${options.speed}", "-Q", "${options.quality}-100", it.absolutePath))
         }.forEach {
             val s0 = it.input.length()

--- a/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressImages.kt
+++ b/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressImages.kt
@@ -1,6 +1,5 @@
 package com.didiglobal.booster.task.compression.pngquant
 
-import com.android.SdkConstants
 import com.android.SdkConstants.DOT_PNG
 import com.didiglobal.booster.compression.CompressionResult
 import com.didiglobal.booster.compression.task.ActionData
@@ -25,9 +24,7 @@ internal open class PngquantCompressImages : AbstractPngquantCompressImages() {
     override fun compress() {
         val pngquant = this.compressor.canonicalPath
 
-        images.parallelStream().filter {
-            this.filter("${it.parent.substringBefore(SdkConstants.RES_QUALIFIER_SEP)}/${it.nameWithoutExtension}")
-        }.map {
+        images.parallelStream().filter(this::shouldIgnore).map {
             ActionData(it, it, listOf(pngquant, "--strip", "--skip-if-larger", "-f", "--ext", DOT_PNG, "-s", "${options.speed}", "-Q", "${options.quality}-100", it.absolutePath))
         }.forEach {
             val s0 = it.input.length()

--- a/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressionVariantProcessor.kt
+++ b/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressionVariantProcessor.kt
@@ -3,6 +3,7 @@ package com.didiglobal.booster.task.compression.pngquant
 import com.android.build.gradle.api.BaseVariant
 import com.didiglobal.booster.annotations.Priority
 import com.didiglobal.booster.compression.CompressionResults
+import com.didiglobal.booster.compression.ResourceNameFilter
 import com.didiglobal.booster.compression.generateReport
 import com.didiglobal.booster.compression.isFlatPngExceptRaw
 import com.didiglobal.booster.compression.isPngExceptRaw
@@ -11,6 +12,7 @@ import com.didiglobal.booster.gradle.aapt2Enabled
 import com.didiglobal.booster.gradle.mergeResourcesTask
 import com.didiglobal.booster.gradle.mergedRes
 import com.didiglobal.booster.gradle.project
+import com.didiglobal.booster.kotlinx.Wildcard
 import com.didiglobal.booster.kotlinx.search
 import com.didiglobal.booster.task.spi.VariantProcessor
 import com.google.auto.service.AutoService
@@ -24,16 +26,25 @@ class PngquantCompressionVariantProcessor : VariantProcessor {
 
     override fun process(variant: BaseVariant) {
         val results = CompressionResults()
-        val filter = if (variant.project.aapt2Enabled) ::isFlatPngExceptRaw else ::isPngExceptRaw
         val compress = variant.project.tasks.withType(CompressImages::class.java).filter {
             it.variant.name == variant.name
         }
+        val filter: ResourceNameFilter = if (variant.project.hasProperty(PROPERTY_IGNORES)) {
+            val ignores = "${variant.project.property(PROPERTY_IGNORES)}".trim().split(',').map(Wildcard.Companion::valueOf).toSet();
+            { res -> ignores.none { it.matches(res) } }
+        } else {
+            { true }
+        }
         Pngquant.get(variant)?.newCompressionTaskCreator()?.createCompressionTask(variant, results, "resources", {
-            variant.mergedRes.search(filter)
-        }, *(compress + variant.mergeResourcesTask).toTypedArray())?.doLast {
+            variant.mergedRes.search(if (variant.project.aapt2Enabled) ::isFlatPngExceptRaw else ::isPngExceptRaw)
+        }, filter, *(compress + variant.mergeResourcesTask).toTypedArray())?.doLast {
             results.generateReport(variant, Build.ARTIFACT)
         }
 
     }
 
 }
+
+private val PROPERTY_PREFIX = Build.ARTIFACT.replace('-', '.')
+
+private val PROPERTY_IGNORES = "$PROPERTY_PREFIX.ignores"

--- a/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/CompressionTaskCreator.kt
+++ b/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/CompressionTaskCreator.kt
@@ -2,6 +2,7 @@ package com.didiglobal.booster.compression
 
 import com.android.build.gradle.api.BaseVariant
 import com.didiglobal.booster.compression.task.CompressImages
+import com.didiglobal.booster.kotlinx.Wildcard
 import org.gradle.api.Task
 import java.io.File
 import kotlin.reflect.KClass
@@ -29,7 +30,7 @@ interface CompressionTaskCreator {
      * @param supplier The image supplier
      * @param deps The dependent tasks
      */
-    fun createCompressionTask(variant: BaseVariant, results: CompressionResults, name: String, supplier: () -> Collection<File>, vararg deps: Task): CompressImages<out CompressionOptions> = createCompressionTask(variant, results, name, supplier, { true }, *deps)
+    fun createCompressionTask(variant: BaseVariant, results: CompressionResults, name: String, supplier: () -> Collection<File>, vararg deps: Task): CompressImages<out CompressionOptions> = createCompressionTask(variant, results, name, supplier, emptySet(), *deps)
 
     /**
      * Returns a task for compression
@@ -38,11 +39,9 @@ interface CompressionTaskCreator {
      * @param results The compression results for report generating
      * @param name The name of task
      * @param supplier The image supplier
-     * @param filter The resource name filter
+     * @param ignores wildcard of the resource name which to be excluded
      * @param deps The dependent tasks
      */
-    fun createCompressionTask(variant: BaseVariant, results: CompressionResults, name: String, supplier: () -> Collection<File>, filter: ResourceNameFilter, vararg deps: Task): CompressImages<out CompressionOptions>
+    fun createCompressionTask(variant: BaseVariant, results: CompressionResults, name: String, supplier: () -> Collection<File>, ignores: Set<Wildcard> = emptySet(), vararg deps: Task): CompressImages<out CompressionOptions>
 
 }
-
-typealias ResourceNameFilter = (String) -> Boolean

--- a/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/CompressionTaskCreator.kt
+++ b/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/CompressionTaskCreator.kt
@@ -29,6 +29,20 @@ interface CompressionTaskCreator {
      * @param supplier The image supplier
      * @param deps The dependent tasks
      */
-    fun createCompressionTask(variant: BaseVariant, results: CompressionResults, name: String, supplier: () -> Collection<File>, vararg deps: Task): CompressImages<out CompressionOptions>
+    fun createCompressionTask(variant: BaseVariant, results: CompressionResults, name: String, supplier: () -> Collection<File>, vararg deps: Task): CompressImages<out CompressionOptions> = createCompressionTask(variant, results, name, supplier, { true }, *deps)
+
+    /**
+     * Returns a task for compression
+     *
+     * @param variant The build variant
+     * @param results The compression results for report generating
+     * @param name The name of task
+     * @param supplier The image supplier
+     * @param filter The resource name filter
+     * @param deps The dependent tasks
+     */
+    fun createCompressionTask(variant: BaseVariant, results: CompressionResults, name: String, supplier: () -> Collection<File>, filter: ResourceNameFilter, vararg deps: Task): CompressImages<out CompressionOptions>
 
 }
+
+typealias ResourceNameFilter = (String) -> Boolean

--- a/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/SimpleCompressionTaskCreator.kt
+++ b/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/SimpleCompressionTaskCreator.kt
@@ -29,6 +29,7 @@ class SimpleCompressionTaskCreator(private val tool: CompressionTool, private va
             task.tool = tool
             task.variant = variant
             task.results = results
+            task.filter = filter
             task.supplier = {
                 supplier().filter { it.length() > 0 }.sortedBy { it }
             }

--- a/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/SimpleCompressionTaskCreator.kt
+++ b/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/SimpleCompressionTaskCreator.kt
@@ -21,7 +21,7 @@ class SimpleCompressionTaskCreator(private val tool: CompressionTool, private va
 
     override fun getCompressionTaskClass(aapt2: Boolean) = compressor(aapt2)
 
-    override fun createCompressionTask(variant: BaseVariant, results: CompressionResults, name: String, supplier: () -> Collection<File>, vararg deps: Task): CompressImages<out CompressionOptions> {
+    override fun createCompressionTask(variant: BaseVariant, results: CompressionResults, name: String, supplier: () -> Collection<File>, filter: (String) -> Boolean, vararg deps: Task): CompressImages<out CompressionOptions> {
         val aapt2 = variant.project.aapt2Enabled
         val install = getCommandInstaller(variant)
 
@@ -30,7 +30,7 @@ class SimpleCompressionTaskCreator(private val tool: CompressionTool, private va
             task.variant = variant
             task.results = results
             task.supplier = {
-                supplier.invoke().filter { it.length() > 0 }.sortedBy { it }
+                supplier().filter { it.length() > 0 }.sortedBy { it }
             }
         }.apply {
             dependsOn(install, deps)

--- a/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/SimpleCompressionTaskCreator.kt
+++ b/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/SimpleCompressionTaskCreator.kt
@@ -3,11 +3,14 @@ package com.didiglobal.booster.compression
 import com.android.build.gradle.api.BaseVariant
 import com.didiglobal.booster.command.CommandInstaller
 import com.didiglobal.booster.compression.task.CompressImages
+import com.didiglobal.booster.compression.task.MATCH_ALL_RESOURCES
+import com.didiglobal.booster.compression.task.excludes
 import com.didiglobal.booster.gradle.aapt2Enabled
 import com.didiglobal.booster.gradle.bundleResourcesTask
 import com.didiglobal.booster.gradle.mergeResourcesTask
 import com.didiglobal.booster.gradle.processResTask
 import com.didiglobal.booster.gradle.project
+import com.didiglobal.booster.kotlinx.Wildcard
 import org.gradle.api.Task
 import java.io.File
 import kotlin.reflect.KClass
@@ -21,7 +24,7 @@ class SimpleCompressionTaskCreator(private val tool: CompressionTool, private va
 
     override fun getCompressionTaskClass(aapt2: Boolean) = compressor(aapt2)
 
-    override fun createCompressionTask(variant: BaseVariant, results: CompressionResults, name: String, supplier: () -> Collection<File>, filter: (String) -> Boolean, vararg deps: Task): CompressImages<out CompressionOptions> {
+    override fun createCompressionTask(variant: BaseVariant, results: CompressionResults, name: String, supplier: () -> Collection<File>, ignores: Set<Wildcard>, vararg deps: Task): CompressImages<out CompressionOptions> {
         val aapt2 = variant.project.aapt2Enabled
         val install = getCommandInstaller(variant)
 
@@ -29,7 +32,7 @@ class SimpleCompressionTaskCreator(private val tool: CompressionTool, private va
             task.tool = tool
             task.variant = variant
             task.results = results
-            task.filter = filter
+            task.filter = if (ignores.isNotEmpty()) excludes(ignores) else MATCH_ALL_RESOURCES
             task.supplier = {
                 supplier().filter { it.length() > 0 }.sortedBy { it }
             }

--- a/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/task/CompressImages.kt
+++ b/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/task/CompressImages.kt
@@ -1,8 +1,8 @@
 package com.didiglobal.booster.compression.task
 
-import com.android.SdkConstants
 import com.android.build.gradle.api.BaseVariant
 import com.didiglobal.booster.aapt2.Aapt2Container
+import com.didiglobal.booster.aapt2.resourceName
 import com.didiglobal.booster.command.Command
 import com.didiglobal.booster.command.CommandInstaller
 import com.didiglobal.booster.compression.CompressionOptions
@@ -57,22 +57,23 @@ abstract class CompressImages<T : CompressionOptions> : DefaultTask() {
     val images: Collection<File>
         get() = supplier()
 
-    protected open fun shouldIgnore(arg: Pair<File, Aapt2Container.Metadata>): Boolean {
+    protected open fun includes(arg: Pair<File, Aapt2Container.Metadata>): Boolean {
         val (input, metadata) = arg
-        return if (!filter(metadata.resourceName)) true else false.also {
-            ignore(input, File(metadata.sourcePath))
+        return if (filter(metadata.resourceName)) true else false.also {
+            ignore(metadata.resourceName, input, File(metadata.sourcePath))
         }
     }
 
-    protected open fun shouldIgnore(input: File): Boolean {
-        return if (!filter("${input.parent.substringBefore(SdkConstants.RES_QUALIFIER_SEP)}/${input.nameWithoutExtension}")) true else false.also {
-            ignore(input, input)
+    protected open fun includes(input: File): Boolean {
+        return if (filter(input.resourceName)) true else false.also {
+            ignore(input.resourceName, input, input)
         }
     }
 
-    private fun ignore(dest: File, src: File) {
+    protected fun ignore(resName: String, dest: File, src: File) {
         val s0 = dest.length()
         results.add(CompressionResult(dest, s0, s0, src))
+        logger.info("${tool.command.name}: exclude $resName $dest => $src")
     }
 
 }

--- a/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/task/CompressImages.kt
+++ b/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/task/CompressImages.kt
@@ -7,6 +7,7 @@ import com.didiglobal.booster.command.CommandInstaller
 import com.didiglobal.booster.compression.CompressionOptions
 import com.didiglobal.booster.compression.CompressionResults
 import com.didiglobal.booster.compression.CompressionTool
+import com.didiglobal.booster.compression.ResourceNameFilter
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -30,6 +31,11 @@ abstract class CompressImages<T : CompressionOptions> : DefaultTask() {
     lateinit var options: T
 
     lateinit var supplier: () -> Collection<File>
+
+    /**
+     * The resource path filter
+     */
+    var filter: ResourceNameFilter = { true }
 
     val compressor: File
         get() = project.tasks.withType(CommandInstaller::class.java).find {

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ allprojects { project ->
     apply plugin: 'de.marcphilipp.nexus-publish'
 
     group = 'com.didiglobal.booster'
-    version = '3.1.0-alpha1'
+    version = '3.1.0-alpha2'
 
     repositories {
         mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ allprojects { project ->
     apply plugin: 'de.marcphilipp.nexus-publish'
 
     group = 'com.didiglobal.booster'
-    version = '3.1.0-alpha3'
+    version = '3.1.0-alpha4'
 
     repositories {
         mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ allprojects { project ->
     apply plugin: 'de.marcphilipp.nexus-publish'
 
     group = 'com.didiglobal.booster'
-    version = '3.1.0-alpha4'
+    version = '3.1.0-alpha5'
 
     repositories {
         mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ allprojects { project ->
     apply plugin: 'de.marcphilipp.nexus-publish'
 
     group = 'com.didiglobal.booster'
-    version = '3.1.0-alpha2'
+    version = '3.1.0-alpha3'
 
     repositories {
         mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ allprojects { project ->
     apply plugin: 'de.marcphilipp.nexus-publish'
 
     group = 'com.didiglobal.booster'
-    version = '3.0.0'
+    version = '3.1.0-alpha1'
 
     repositories {
         mavenLocal()


### PR DESCRIPTION
- Support property `booster.task.compression.pngquant.ignores` to ignore resources by wildcards
- Support property `booster.task.compression.cwebp.ignores` to ignore resources by wildcards