### PR TITLE
Fix bug when install at android-R machine: no compress arsc file.

### DIFF
--- a/booster-task-compression-processed-res/src/main/kotlin/com/didiglobal/booster/task/compression/processed/res/ProcessedResourcesCompressionVariantProcessor.kt
+++ b/booster-task-compression-processed-res/src/main/kotlin/com/didiglobal/booster/task/compression/processed/res/ProcessedResourcesCompressionVariantProcessor.kt
@@ -123,7 +123,7 @@ internal val NO_COMPRESS = setOf(
         "mpg", "mpeg", "mid", "midi", "smf", "jet",
         "rtttl", "imy", "xmf", "mp4", "m4a",
         "m4v", "3gp", "3gpp", "3g2", "3gpp2",
-        "amr", "awb", "wma", "wmv", "webm", "mkv"
+        "amr", "awb", "wma", "wmv", "webm", "mkv", "arsc"
 )
 
 internal val percentage: (Number) -> String = DecimalFormat("#,##0.00'%'")::format


### PR DESCRIPTION
increase compatibility with Android R's feature:

Apps that target Android 11 (API level 30) or higher can't be installed if they contain a compressed resources.arsc file or if this file is not aligned on a 4-byte boundary.