### PR TITLE
Fix bug when classpath size greater than 1 and end with 'jar' or 'zip'

### DIFF
--- a/booster-transform-javassist/src/main/kotlin/com/didiglobal/booster/transform/javassist/JavassistTransformer.kt
+++ b/booster-transform-javassist/src/main/kotlin/com/didiglobal/booster/transform/javassist/JavassistTransformer.kt
@@ -44,9 +44,12 @@ class JavassistTransformer : Transformer {
     }
 
     override fun onPreTransform(context: TransformContext) {
-        this.pool.appendClassPath(context.bootClasspath.joinToString(File.pathSeparator) { it.canonicalPath })
-        this.pool.appendClassPath(context.compileClasspath.joinToString(File.pathSeparator) { it.canonicalPath })
-
+        context.bootClasspath.forEach { file ->
+            this.pool.appendClassPath(file.canonicalPath)
+        }
+        context.compileClasspath.forEach { file ->
+            this.pool.appendClassPath(file.canonicalPath)
+        }
         this.transformers.forEach { transformer ->
             this.threadMxBean.sumCpuTime(transformer) {
                 transformer.onPreTransform(context)


### PR DESCRIPTION
### issue: 
#250 
### 产生原因: 
当context.bootClasspath或context.compileClasspath的size > 1 且结尾为'.jar'或'.zip'时, ClassPoolTail.makePathObject会进入到return new JarClassPath(pathname), 导致javassist.NotFoundException

