### PR TITLE
add getReport  Api for BaseVariant like as TransformContext

### DIFF
--- a/booster-android-gradle-api/src/main/kotlin/com/didiglobal/booster/gradle/BaseVariant.kt
+++ b/booster-android-gradle-api/src/main/kotlin/com/didiglobal/booster/gradle/BaseVariant.kt
@@ -7,6 +7,7 @@ import com.android.build.gradle.tasks.ProcessAndroidResources
 import com.android.builder.core.VariantType
 import com.android.sdklib.AndroidVersion
 import com.android.sdklib.BuildToolInfo
+import com.didiglobal.booster.kotlinx.file
 import org.gradle.api.Incubating
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -23,6 +24,12 @@ import java.io.File
 @Suppress("DEPRECATION")
 val BaseVariant.project: Project
     get() = AGP.run { project }
+
+
+fun BaseVariant.getReport(artifactName: String, fileName: String): File {
+    return project.buildDir.file("reports", artifactName, name, fileName)
+}
+
 
 /**
  * The `android` extension associates with this variant

--- a/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/CompressionReport.kt
+++ b/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/CompressionReport.kt
@@ -2,6 +2,7 @@ package com.didiglobal.booster.compression
 
 import com.android.SdkConstants
 import com.android.build.gradle.api.BaseVariant
+import com.didiglobal.booster.gradle.getReport
 import com.didiglobal.booster.gradle.project
 import com.didiglobal.booster.kotlinx.Octuple
 import com.didiglobal.booster.kotlinx.Quadruple
@@ -38,7 +39,7 @@ fun CompressionResults.generateReport(variant: BaseVariant, artifact: String) {
     val maxWith7 = table.map { it.seventh.length }.max() ?: 0
     val fullWith = maxWith1 + maxWith5 + maxWith6 + 8
 
-    variant.project.buildDir.file("reports", artifact, variant.name, "report.txt").touch().printWriter().use { logger ->
+    variant.getReport(artifact, "report.txt").touch().printWriter().use { logger ->
         // sort by reduced size and original size
         table.sortedWith(compareByDescending<CompressionReport> {
             it.fourth


### PR DESCRIPTION
we knows when we custom transformer base on classTransformer, we can use getReport api from TransformContext,
but when we custom processor base on  VariantProcessor, there is no api like getReport

so，may be it is better to make them the same