### PR TITLE
add  api  "variant.mergedNativeLibs" 

### DIFF
--- a/booster-android-gradle-api/src/main/kotlin/com/didiglobal/booster/gradle/BaseVariant.kt
+++ b/booster-android-gradle-api/src/main/kotlin/com/didiglobal/booster/gradle/BaseVariant.kt
@@ -169,6 +169,14 @@ val BaseVariant.mergedAssets: Collection<File>
     }
 
 /**
+ * The output directory of merged native libs
+ */
+val BaseVariant.mergedNativeLibs: Collection<File>
+    get() = AGP.run {
+        mergedNativeLibs
+    }
+
+/**
  * The output directory of processed resources: *resources-**variant**.ap\_*
  */
 val BaseVariant.processedRes: Collection<File>

--- a/booster-android-gradle-compat/src/main/kotlin/com/didiglobal/booster/gradle/AGPInterface.kt
+++ b/booster-android-gradle-compat/src/main/kotlin/com/didiglobal/booster/gradle/AGPInterface.kt
@@ -146,6 +146,8 @@ interface AGPInterface {
 
     val BaseVariant.mergedAssets: Collection<File>
 
+    val BaseVariant.mergedNativeLibs: Collection<File>
+
     val BaseVariant.processedRes: Collection<File>
 
     val BaseVariant.symbolList: Collection<File>

--- a/booster-android-gradle-v3_3/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_3/V33.kt
+++ b/booster-android-gradle-v3_3/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_3/V33.kt
@@ -161,7 +161,7 @@ internal object V33 : AGPInterface {
         get() = getFinalArtifactFiles(InternalArtifactType.MERGED_RES)
 
     override val BaseVariant.mergedNativeLibs: Collection<File>
-        get() = setOf((File("${project.buildDir.path}/${AndroidProject.FD_INTERMEDIATES}/transforms/mergeJniLibs/$name")))
+        get() = setOf((File("${project.buildDir.path}${File.separatorChar}${AndroidProject.FD_INTERMEDIATES}${File.separatorChar}transforms${File.separatorChar}mergeJniLibs${File.separatorChar}$name")))
 
     override val BaseVariant.mergedAssets: Collection<File>
         get() = getFinalArtifactFiles(when (this) {

--- a/booster-android-gradle-v3_3/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_3/V33.kt
+++ b/booster-android-gradle-v3_3/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_3/V33.kt
@@ -18,6 +18,7 @@ import com.android.build.gradle.internal.scope.MissingTaskOutputException
 import com.android.build.gradle.internal.scope.VariantScope
 import com.android.build.gradle.internal.variant.BaseVariantData
 import com.android.builder.core.VariantType
+import com.android.builder.model.AndroidProject
 import com.android.builder.model.ApiVersion
 import com.android.sdklib.AndroidVersion
 import com.android.sdklib.BuildToolInfo
@@ -158,6 +159,9 @@ internal object V33 : AGPInterface {
 
     override val BaseVariant.mergedRes: Collection<File>
         get() = getFinalArtifactFiles(InternalArtifactType.MERGED_RES)
+
+    override val BaseVariant.mergedNativeLibs: Collection<File>
+        get() = setOf((File("${project.buildDir.path}/${AndroidProject.FD_INTERMEDIATES}/transforms/mergeJniLibs/$name")))
 
     override val BaseVariant.mergedAssets: Collection<File>
         get() = getFinalArtifactFiles(when (this) {

--- a/booster-android-gradle-v3_4/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_4/V34.kt
+++ b/booster-android-gradle-v3_4/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_4/V34.kt
@@ -20,6 +20,7 @@ import com.android.build.gradle.internal.scope.getOutputDir
 import com.android.build.gradle.internal.variant.BaseVariantData
 import com.android.build.gradle.options.BooleanOption
 import com.android.builder.core.VariantType
+import com.android.builder.model.AndroidProject.FD_INTERMEDIATES
 import com.android.builder.model.ApiVersion
 import com.android.sdklib.AndroidVersion
 import com.android.sdklib.BuildToolInfo
@@ -160,6 +161,9 @@ object V34 : AGPInterface {
 
     override val BaseVariant.mergedRes: Collection<File>
         get() = getFinalArtifactFiles(InternalArtifactType.MERGED_RES)
+
+    override val BaseVariant.mergedNativeLibs: Collection<File>
+        get() = setOf((File("${project.buildDir.path}/$FD_INTERMEDIATES/transforms/mergeJniLibs/$name")))
 
     override val BaseVariant.mergedAssets: Collection<File>
         get() = getFinalArtifactFiles(when (this) {

--- a/booster-android-gradle-v3_4/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_4/V34.kt
+++ b/booster-android-gradle-v3_4/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_4/V34.kt
@@ -20,7 +20,7 @@ import com.android.build.gradle.internal.scope.getOutputDir
 import com.android.build.gradle.internal.variant.BaseVariantData
 import com.android.build.gradle.options.BooleanOption
 import com.android.builder.core.VariantType
-import com.android.builder.model.AndroidProject.FD_INTERMEDIATES
+import com.android.builder.model.AndroidProject
 import com.android.builder.model.ApiVersion
 import com.android.sdklib.AndroidVersion
 import com.android.sdklib.BuildToolInfo
@@ -163,7 +163,7 @@ object V34 : AGPInterface {
         get() = getFinalArtifactFiles(InternalArtifactType.MERGED_RES)
 
     override val BaseVariant.mergedNativeLibs: Collection<File>
-        get() = setOf((File("${project.buildDir.path}/$FD_INTERMEDIATES/transforms/mergeJniLibs/$name")))
+        get() = setOf((File("${project.buildDir.path}${File.separatorChar}${AndroidProject.FD_INTERMEDIATES}${File.separatorChar}transforms${File.separatorChar}mergeJniLibs${File.separatorChar}$name")))
 
     override val BaseVariant.mergedAssets: Collection<File>
         get() = getFinalArtifactFiles(when (this) {

--- a/booster-android-gradle-v3_5/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_5/V35.kt
+++ b/booster-android-gradle-v3_5/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_5/V35.kt
@@ -174,6 +174,9 @@ internal object V35 : AGPInterface {
     override val BaseVariant.mergedRes: Collection<File>
         get() = getFinalArtifactFiles(InternalArtifactType.MERGED_RES)
 
+    override val BaseVariant.mergedNativeLibs: Collection<File>
+        get() = getFinalArtifactFiles(InternalArtifactType.MERGED_NATIVE_LIBS)
+
     @Suppress("UnstableApiUsage")
     override val BaseVariant.mergedAssets: Collection<File>
         get() = listOf(when (this) {

--- a/booster-android-gradle-v3_6/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_6/V36.kt
+++ b/booster-android-gradle-v3_6/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_6/V36.kt
@@ -159,6 +159,9 @@ object V36 : AGPInterface {
     override val BaseVariant.mergedRes: Collection<File>
         get() = getFinalArtifactFiles(InternalArtifactType.MERGED_RES)
 
+    override val BaseVariant.mergedNativeLibs: Collection<File>
+        get() = getFinalArtifactFiles(InternalArtifactType.MERGED_NATIVE_LIBS)
+
     @Suppress("UnstableApiUsage")
     override val BaseVariant.mergedAssets: Collection<File>
         get() = getFinalArtifactFiles(when (this) {

--- a/booster-android-gradle-v4_0/src/main/kotlin/com/didiglobal/booster/android/gradle/v4_0/V40.kt
+++ b/booster-android-gradle-v4_0/src/main/kotlin/com/didiglobal/booster/android/gradle/v4_0/V40.kt
@@ -156,6 +156,9 @@ internal object V40 : AGPInterface {
     override val BaseVariant.mergedRes: Collection<File>
         get() = getFinalArtifactFiles(InternalArtifactType.MERGED_RES)
 
+    override val BaseVariant.mergedNativeLibs: Collection<File>
+        get() = getFinalArtifactFiles(InternalArtifactType.MERGED_NATIVE_LIBS)
+
     override val BaseVariant.mergedAssets: Collection<File>
         get() = when (this) {
             is ApplicationVariant -> getFinalArtifactFiles(InternalArtifactType.MERGED_ASSETS)

--- a/booster-android-gradle-v4_1/src/main/kotlin/com/didiglobal/booster/android/gradle/v4_1/V41.kt
+++ b/booster-android-gradle-v4_1/src/main/kotlin/com/didiglobal/booster/android/gradle/v4_1/V41.kt
@@ -165,6 +165,9 @@ internal object V41 : AGPInterface {
     override val BaseVariant.mergedRes: Collection<File>
         get() = getFinalArtifactFiles(InternalArtifactType.MERGED_RES)
 
+    override val BaseVariant.mergedNativeLibs: Collection<File>
+        get() = getFinalArtifactFiles(InternalArtifactType.MERGED_NATIVE_LIBS)
+
     override val BaseVariant.mergedAssets: Collection<File>
         get() = when (this) {
             is ApplicationVariant -> getFinalArtifactFiles(InternalArtifactType.MERGED_ASSETS)

--- a/booster-android-gradle-v4_2/src/main/kotlin/com/didiglobal/booster/android/gradle/v4_2/V42.kt
+++ b/booster-android-gradle-v4_2/src/main/kotlin/com/didiglobal/booster/android/gradle/v4_2/V42.kt
@@ -169,6 +169,9 @@ internal object V42 : AGPInterface {
     override val BaseVariant.mergedRes: Collection<File>
         get() = getFinalArtifactFiles(InternalArtifactType.MERGED_RES)
 
+    override val BaseVariant.mergedNativeLibs: Collection<File>
+        get() = getFinalArtifactFiles(InternalArtifactType.MERGED_NATIVE_LIBS)
+
     override val BaseVariant.mergedAssets: Collection<File>
         get() = when (this) {
             is ApplicationVariant -> getFinalArtifactFiles(InternalArtifactType.MERGED_ASSETS)

--- a/booster-android-gradle-v7_0/src/main/kotlin/com/didiglobal/booster/android/gradle/v7_0/V70.kt
+++ b/booster-android-gradle-v7_0/src/main/kotlin/com/didiglobal/booster/android/gradle/v7_0/V70.kt
@@ -177,6 +177,9 @@ internal object V70 : AGPInterface {
     override val BaseVariant.mergedRes: Collection<File>
         get() = getFinalArtifactFiles(InternalArtifactType.MERGED_RES)
 
+    override val BaseVariant.mergedNativeLibs: Collection<File>
+        get() = getFinalArtifactFiles(InternalArtifactType.MERGED_NATIVE_LIBS)
+
     override val BaseVariant.mergedAssets: Collection<File>
         get() = when (this) {
             is ApplicationVariant -> getFinalArtifactFiles(InternalArtifactType.MERGED_ASSETS)


### PR DESCRIPTION


but the agp v33 and v34 so file path like this:  "app/build/intermediates/transforms/mergeJniLibs"

task is :  "app:transformNativeLibsWithMergeJniLibsForDebug"

please notice v33.kt and v34.kt,  these 2 agp versions can not get path through InternalArtifactType or varint.allArtifacts.