### PR TITLE
add api  mergeNativeLibsTaskProvider

### DIFF
--- a/booster-android-gradle-api/src/main/kotlin/com/didiglobal/booster/gradle/BaseVariant.kt
+++ b/booster-android-gradle-api/src/main/kotlin/com/didiglobal/booster/gradle/BaseVariant.kt
@@ -66,6 +66,9 @@ val BaseVariant.mergeAssetsTaskProvider: TaskProvider<out Task>
 val BaseVariant.mergeResourcesTaskProvider: TaskProvider<out Task>
     get() = AGP.run { mergeResourcesTaskProvider }
 
+val BaseVariant.mergeNativeLibsTaskProvider:TaskProvider<out Task>
+    get() = AGP.run { mergeNativeLibsTaskProvider }
+
 val BaseVariant.processJavaResourcesTaskProvider: TaskProvider<out Task>
     get() = AGP.run { processJavaResourcesTaskProvider }
 

--- a/booster-android-gradle-compat/src/main/kotlin/com/didiglobal/booster/gradle/AGPInterface.kt
+++ b/booster-android-gradle-compat/src/main/kotlin/com/didiglobal/booster/gradle/AGPInterface.kt
@@ -80,6 +80,7 @@ interface AGPInterface {
     val BaseVariant.mergeResourcesTask: Task
         get() = mergeResourcesTaskProvider.get()
 
+
     @Deprecated(
             message = "Use processJavaResourcesTaskProvider instead",
             replaceWith = ReplaceWith(expression = "processJavaResourcesTaskProvider"),
@@ -113,6 +114,8 @@ interface AGPInterface {
     val BaseVariant.mergeAssetsTaskProvider: TaskProvider<out Task>
 
     val BaseVariant.mergeResourcesTaskProvider: TaskProvider<out Task>
+
+    val BaseVariant.mergeNativeLibsTaskProvider: TaskProvider<out Task>
 
     val BaseVariant.processJavaResourcesTaskProvider: TaskProvider<out Task>
 

--- a/booster-android-gradle-v3_3/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_3/V33.kt
+++ b/booster-android-gradle-v3_3/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_3/V33.kt
@@ -72,6 +72,9 @@ internal object V33 : AGPInterface {
     override val BaseVariant.mergeResourcesTaskProvider: TaskProvider<out Task>
         get() = mergeResourcesProvider
 
+    override val BaseVariant.mergeNativeLibsTaskProvider: TaskProvider<out Task>
+        get() = project.tasks.named("transformNativeLibsWithMergeJniLibsFor${name.capitalize()}")
+
     override val BaseVariant.processJavaResourcesTaskProvider: TaskProvider<out Task>
         get() = processJavaResourcesProvider
 

--- a/booster-android-gradle-v3_4/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_4/V34.kt
+++ b/booster-android-gradle-v3_4/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_4/V34.kt
@@ -74,6 +74,9 @@ object V34 : AGPInterface {
     override val BaseVariant.mergeResourcesTaskProvider: TaskProvider<out Task>
         get() = mergeResourcesProvider
 
+    override val BaseVariant.mergeNativeLibsTaskProvider: TaskProvider<out Task>
+        get() = project.tasks.named("transformNativeLibsWithMergeJniLibsFor${name.capitalize()}")
+
     override val BaseVariant.processJavaResourcesTaskProvider: TaskProvider<out Task>
         get() = processJavaResourcesProvider
 

--- a/booster-android-gradle-v3_5/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_5/V35.kt
+++ b/booster-android-gradle-v3_5/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_5/V35.kt
@@ -72,6 +72,10 @@ internal object V35 : AGPInterface {
     override val BaseVariant.mergeResourcesTaskProvider: TaskProvider<out Task>
         get() = mergeResourcesProvider
 
+    override val BaseVariant.mergeNativeLibsTaskProvider: TaskProvider<out Task>
+        get() = project.tasks.named(getTaskName("merge", "NativeLibs"))
+
+
     override val BaseVariant.processJavaResourcesTaskProvider: TaskProvider<out Task>
         get() = processJavaResourcesProvider
 

--- a/booster-android-gradle-v3_6/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_6/V36.kt
+++ b/booster-android-gradle-v3_6/src/main/kotlin/com/didiglobal/booster/android/gradle/v3_6/V36.kt
@@ -79,6 +79,9 @@ object V36 : AGPInterface {
             mergeResourcesProvider
         }
 
+    override val BaseVariant.mergeNativeLibsTaskProvider: TaskProvider<out Task>
+        get() = project.tasks.named(getTaskName("merge", "NativeLibs"))
+
     override val BaseVariant.processJavaResourcesTaskProvider: TaskProvider<out Task>
         get() = processJavaResourcesProvider
 

--- a/booster-android-gradle-v4_0/src/main/kotlin/com/didiglobal/booster/android/gradle/v4_0/V40.kt
+++ b/booster-android-gradle-v4_0/src/main/kotlin/com/didiglobal/booster/android/gradle/v4_0/V40.kt
@@ -76,6 +76,9 @@ internal object V40 : AGPInterface {
             mergeResourcesProvider
         }
 
+    override val BaseVariant.mergeNativeLibsTaskProvider: TaskProvider<out Task>
+        get() = project.tasks.named(getTaskName("merge", "NativeLibs"))
+
     override val BaseVariant.processJavaResourcesTaskProvider: TaskProvider<out Task>
         get() = processJavaResourcesProvider
 

--- a/booster-android-gradle-v4_1/src/main/kotlin/com/didiglobal/booster/android/gradle/v4_1/V41.kt
+++ b/booster-android-gradle-v4_1/src/main/kotlin/com/didiglobal/booster/android/gradle/v4_1/V41.kt
@@ -89,6 +89,9 @@ internal object V41 : AGPInterface {
             mergeResourcesProvider
         }
 
+    override val BaseVariant.mergeNativeLibsTaskProvider: TaskProvider<out Task>
+        get() = project.tasks.named(getTaskName("merge", "NativeLibs"))
+
     override val BaseVariant.processJavaResourcesTaskProvider: TaskProvider<out Task>
         get() = processJavaResourcesProvider
 

--- a/booster-android-gradle-v4_2/src/main/kotlin/com/didiglobal/booster/android/gradle/v4_2/V42.kt
+++ b/booster-android-gradle-v4_2/src/main/kotlin/com/didiglobal/booster/android/gradle/v4_2/V42.kt
@@ -89,6 +89,9 @@ internal object V42 : AGPInterface {
             mergeResourcesProvider
         }
 
+    override val BaseVariant.mergeNativeLibsTaskProvider: TaskProvider<out Task>
+        get() = project.tasks.named(getTaskName("merge", "NativeLibs"))
+
     override val BaseVariant.processJavaResourcesTaskProvider: TaskProvider<out Task>
         get() = processJavaResourcesProvider
 

--- a/booster-android-gradle-v7_0/src/main/kotlin/com/didiglobal/booster/android/gradle/v7_0/V70.kt
+++ b/booster-android-gradle-v7_0/src/main/kotlin/com/didiglobal/booster/android/gradle/v7_0/V70.kt
@@ -97,6 +97,9 @@ internal object V70 : AGPInterface {
             mergeResourcesProvider
         }
 
+    override val BaseVariant.mergeNativeLibsTaskProvider: TaskProvider<out Task>
+        get() = project.tasks.named(getTaskName("merge", "NativeLibs"))
+
     override val BaseVariant.processJavaResourcesTaskProvider: TaskProvider<out Task>
         get() = processJavaResourcesProvider
 


### PR DESCRIPTION
add api  mergeNativeLibsTaskProvider  for pair api mergeNativeLibs

in gradle v33 and v34  the task is

:app:transformNativeLibsWithMergeJniLibsForRelease

or 

:app:transformNativeLibsWithMergeJniLibsForDebug

the name takes varint name

