### PR TITLE
修复ShadowScheduledThreadPoolExecutor在Android 5.1.1及以下版本兼容性问题

### DIFF
--- a/booster-android-instrument-thread/src/main/java/com/didiglobal/booster/instrument/ShadowScheduledThreadPoolExecutor.java
+++ b/booster-android-instrument-thread/src/main/java/com/didiglobal/booster/instrument/ShadowScheduledThreadPoolExecutor.java
@@ -3,6 +3,7 @@ package com.didiglobal.booster.instrument;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author johnsonlee
@@ -40,6 +41,9 @@ public class ShadowScheduledThreadPoolExecutor extends ScheduledThreadPoolExecut
     ) {
         super(corePoolSize, new NamedThreadFactory(prefix));
         if (optimize) {
+            if(getKeepAliveTime(TimeUnit.NANOSECONDS) <= 0L) {
+                setKeepAliveTime(10L, TimeUnit.MILLISECONDS);
+            }
             allowCoreThreadTimeOut(true);
         }
     }
@@ -79,6 +83,9 @@ public class ShadowScheduledThreadPoolExecutor extends ScheduledThreadPoolExecut
     ) {
         super(corePoolSize, new NamedThreadFactory(threadFactory, prefix));
         if (optimize) {
+            if(getKeepAliveTime(TimeUnit.NANOSECONDS) <= 0L) {
+                setKeepAliveTime(10L, TimeUnit.MILLISECONDS);
+            }
             allowCoreThreadTimeOut(true);
         }
     }
@@ -118,6 +125,9 @@ public class ShadowScheduledThreadPoolExecutor extends ScheduledThreadPoolExecut
     ) {
         super(corePoolSize, new NamedThreadFactory(prefix), handler);
         if (optimize) {
+            if(getKeepAliveTime(TimeUnit.NANOSECONDS) <= 0L) {
+                setKeepAliveTime(10L, TimeUnit.MILLISECONDS);
+            }
             allowCoreThreadTimeOut(true);
         }
     }
@@ -161,6 +171,9 @@ public class ShadowScheduledThreadPoolExecutor extends ScheduledThreadPoolExecut
     ) {
         super(corePoolSize, new NamedThreadFactory(threadFactory, prefix), handler);
         if (optimize) {
+            if(getKeepAliveTime(TimeUnit.NANOSECONDS) <= 0L) {
+                setKeepAliveTime(10L, TimeUnit.MILLISECONDS);
+            }
             allowCoreThreadTimeOut(true);
         }
     }


### PR DESCRIPTION
在Android 5.1.1及以下版本由于在ScheduledThreadPoolExecutor的实现中，默认的KeepAliveTime为0, 导致在调用allowCoreThreadTimeOut方法时keepAliveTime校验失败从而抛出IllegalArgumentException异常的问题。

有问题的Android 5.1.1版本 源码：http://androidxref.com/5.1.1_r6/xref/libcore/luni/src/main/java/java/util/concurrent/ScheduledThreadPoolExecutor.java#399

没问题的Android6.0.0版本源码：
http://androidxref.com/6.0.0_r1/xref/libcore/luni/src/main/java/java/util/concurrent/ScheduledThreadPoolExecutor.java#419