### PR TITLE
修复 当agp版本>=7.2.0 时 图片压缩任务失败的 bug

### DIFF
--- a/booster-android-gradle-api/src/main/kotlin/com/didiglobal/booster/gradle/Version.kt
+++ b/booster-android-gradle-api/src/main/kotlin/com/didiglobal/booster/gradle/Version.kt
@@ -13,3 +13,4 @@ val GTE_V4_2: Boolean by lazy { AGP.revision.major > 4 || (AGP.revision.major ==
 val GTE_V4_1: Boolean by lazy { AGP.revision.major > 4 || (AGP.revision.major == 4 && AGP.revision.minor >= 1) }
 
 val GTE_V7_X: Boolean by lazy { AGP.revision.major >= 7 }
+val GTE_V7_2: Boolean by lazy { AGP.revision.major > 7 || (AGP.revision.major == 7 && AGP.revision.minor >= 2) }

--- a/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressFlatImages.kt
+++ b/booster-task-compression-cwebp/src/main/kotlin/com/didiglobal/booster/task/compression/cwebp/CwebpCompressFlatImages.kt
@@ -57,7 +57,7 @@ internal abstract class CwebpCompressFlatImages : AbstractCwebpCompressImages() 
         }
 
         images().parallelStream().map {
-            it to it.metadata
+            it to it.metadata.remap()
         }.filter(this::includes).filter(isNotLauncherIcon).filter {
             filter(File(it.second.sourcePath))
         }.map {

--- a/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressFlatImages.kt
+++ b/booster-task-compression-pngquant/src/main/kotlin/com/didiglobal/booster/task/compression/pngquant/PngquantCompressFlatImages.kt
@@ -46,7 +46,7 @@ internal abstract class PngquantCompressFlatImages : AbstractPngquantCompressIma
         compressedRes.file(FD_RES_DRAWABLE).mkdirs()
 
         images().parallelStream().map {
-            it to it.metadata
+            it to it.metadata.remap()
         }.filter(this::includes).map {
             val output = compressedRes.file("${it.second.resourcePath.substringBeforeLast('.')}$DOT_PNG")
             Aapt2ActionData(it.first, it.second, output,

--- a/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/SimpleCompressionTaskCreator.kt
+++ b/booster-task-compression/src/main/kotlin/com/didiglobal/booster/compression/SimpleCompressionTaskCreator.kt
@@ -13,6 +13,8 @@ import com.didiglobal.booster.gradle.mergeResourcesTaskProvider
 import com.didiglobal.booster.gradle.preBuildTaskProvider
 import com.didiglobal.booster.gradle.processResTaskProvider
 import com.didiglobal.booster.gradle.project
+import com.didiglobal.booster.gradle.GTE_V7_2
+import com.didiglobal.booster.gradle.getTaskName
 import com.didiglobal.booster.kotlinx.Wildcard
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -53,6 +55,10 @@ class SimpleCompressionTaskCreator(private val tool: CompressionTool, private va
             task.images = lazy(supplier)::value
         }.apply {
             dependsOn(install)
+            // only agp >=7.2.0 has this mapSourceTask, when mapSourceTask finished,u can get the map file
+            if (GTE_V7_2) {
+                dependsOn(variant.getTaskName("map", "SourceSetPaths"))
+            }
             deps.forEach { dependsOn(it) }
             variant.processResTaskProvider?.dependsOn(this)
             variant.bundleResourcesTaskProvider?.dependsOn(this)


### PR DESCRIPTION
当agp 版本>=7.2.0时，flat 文件中包含的path信息 为一种特殊的相对路径写法，导致从flat提取出来的路径 无法正确读取文件，
经过排查 当7.2.0 新增了一个任务 修改了flat文件中的path，这个任务会生成一个map文件 来标注 相对路径和绝对路径的关系，

所以只要读取这个文件 建立map关系，然后替换掉metadata中的 路径即可 解决该问题，否则 agp>7.2.0是 图片压缩成webp任务 会因为找不到文件而执行失败