### PR TITLE
fix 4.12.0 transformClassesWithBooster 无法注册成功的bug

### DIFF
--- a/booster-gradle-plugin/src/main/kotlin/com/didiglobal/booster/gradle/BoosterPlugin.kt
+++ b/booster-gradle-plugin/src/main/kotlin/com/didiglobal/booster/gradle/BoosterPlugin.kt
@@ -31,6 +31,7 @@ class BoosterPlugin : Plugin<Project> {
                 project.setup(processors)
             }
         }
+        project.getAndroid<BaseExtension>().registerTransform(BoosterTransform.newInstance(project))
     }
 
     private fun Project.setup(processors: List<VariantProcessor>) {
@@ -40,7 +41,6 @@ class BoosterPlugin : Plugin<Project> {
             is LibraryExtension -> android.libraryVariants
             else -> emptyList<BaseVariant>()
         }.takeIf<Collection<BaseVariant>>(Collection<BaseVariant>::isNotEmpty)?.let { variants ->
-            android.registerTransform(BoosterTransform.newInstance(project))
             variants.forEach { variant ->
                 processors.forEach { processor ->
                     processor.process(variant)


### PR DESCRIPTION
4.12.0 中 在afterEvaluate 中调用registerTransform 会导致 transformClassesWithBooster这个task 注册不上 ,从而字节码修改任务都失败, 似乎必须要从afterEvaluate 移出来 才可以