### PR TITLE
升级javassist版本 ，否则宿主工程使用JavaVersion.VERSION_17 编译时，会出现字节码版本不同 导致javass…

### DIFF
--- a/booster-transform-javassist/build.gradle
+++ b/booster-transform-javassist/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     api project(':booster-build')
     api project(':booster-transform-spi')
     api project(':booster-transform-util')
-    api 'org.javassist:javassist:3.25.0-GA'
+    api 'org.javassist:javassist:3.30.2-GA'
     api 'com.google.auto.service:auto-service:1.0'
 }


### PR DESCRIPTION
宿主工程如果使用JavaVersion.VERSION_17  编译，会因为Javassist版本过低 导致字节码读写失败 从而编译失败
升级Javassist版本可以解决该问题